### PR TITLE
riotIdGameName istead of summonerName

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -171,6 +171,9 @@ export type IResponseActivePlay = {
   >;
   level: number;
   summonerName: string;
+  riotId: string;
+  riotIdGameName: string;
+  riotIdTagLine: string;
   teamRelativeColors: boolean;
 };
 

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -7,7 +7,7 @@ export function registerEvents() {
   GameEventListener.on("event", (event) => {
     switch (event.EventName) {
       case "ChampionKill": {
-        if (event.VictimName === RespawnTimer.getSummonerName()) {
+        if (event.VictimName === RespawnTimer.getRiotIdGameName()) {
           RespawnTimer.start(event.EventTime);
           StatusBar.setStatus(StatusBarStatus.Timing);
         }
@@ -18,8 +18,8 @@ export function registerEvents() {
 
   GameEventListener.on("connected", () => {
     RespawnTimer.init()
-      .then((summonerName) =>
-        StatusBar.setStatus(StatusBarStatus.Connected, summonerName)
+      .then((riotIdGameName) =>
+        StatusBar.setStatus(StatusBarStatus.Connected, riotIdGameName)
       )
       .catch(() => Notication.failedToLoadSummonerInfo());
   });

--- a/src/respawn-timer.ts
+++ b/src/respawn-timer.ts
@@ -16,7 +16,7 @@ export const RespawnTimer =
     private gameMode = "";
     private respawnTime = 0;
     private remainingTimeInterval: NodeJS.Timeout | null = null;
-    private summonerName = "";
+    private riotIdGameName = "";
 
     init() {
       return new Promise<string>((resolve, reject) => {
@@ -25,8 +25,8 @@ export const RespawnTimer =
           gameStats: IResponseGamestats
         ) => {
           this.gameMode = gameStats.gameMode;
-          this.summonerName = activePlayer.summonerName;
-          return activePlayer.summonerName;
+          this.riotIdGameName = activePlayer.riotIdGameName;
+          return activePlayer.riotIdGameName;
         };
 
         Promise.all([APIClient.getActivePlayer(), APIClient.getGameStats()])
@@ -145,7 +145,7 @@ export const RespawnTimer =
       }
     }
 
-    getSummonerName() {
-      return this.summonerName;
+    getRiotIdGameName() {
+      return this.riotIdGameName;
     }
   })();


### PR DESCRIPTION
use riotIdGameName istead of summonerName since activeplayer returns riotId in this field:
![image](https://github.com/user-attachments/assets/fe817101-37ca-4382-9383-b8b10d05cf2d)
but eventdata uses player name:
![image](https://github.com/user-attachments/assets/4c847f0d-c6c1-4230-9b90-c7a90a103044)
